### PR TITLE
fix: 解决了firefox的问题，可能解决了safari的问题

### DIFF
--- a/html/document.less
+++ b/html/document.less
@@ -394,15 +394,15 @@ input {
         color: var(--color-font);
     }
 }
-html[data-is-chrome="false"]{
+// html[data-is-chrome="false"]{
 
-    .is-not-chrome{
-        display: block;
-    }
-    .app{
-        display: none;
-    }
-}
+//     .is-not-chrome{
+//         display: block;
+//     }
+//     .app{
+//         display: none;
+//     }
+// }
 
 
 .app{

--- a/html/make.js
+++ b/html/make.js
@@ -1,6 +1,10 @@
 
 
 const ios = /iphone|ipad|ipod|ios/i.test(navigator.userAgent);
+const isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
+  navigator.userAgent &&
+  navigator.userAgent.indexOf('CriOS') == -1 &&
+  navigator.userAgent.indexOf('FxiOS') == -1;
 const isMobile = document.body.offsetWidth < 700;
 // const whiteColor = '#e8e8e8'
 const whiteColor = '#e4e0e8'
@@ -213,7 +217,11 @@ const make = ({
 
         if(shadow){
             ctx.shadowColor = shadowColor;//'orange';
-            ctx.shadowBlur = space * 2;
+            if (isSafari) {
+              ctx.shadowBlur = space * 1; // or `space * .8`, discuss it!
+            } else {
+              ctx.shadowBlur = space * 2;
+            }
         }
     }
 
@@ -239,7 +247,9 @@ const make = ({
 
         // console.log(text,metrics)
         const width = Math.ceil(metrics.width) - letterSpacing + fontPadding * 2;
-        const height = Math.ceil(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent) + fontPadding * 2;
+        const height = isNaN(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent)
+          ? fontSize + fontPadding * 2 // browser do not support `metrics.fontBoundingBoxDescent/Ascent`
+          : Math.ceil(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent) + fontPadding * 2
 
         // console.log({text,width,height})
         canvas.width = width;
@@ -452,7 +462,9 @@ const make = ({
         if(/^[a-zA-Z][a-z ]+$/.test(text)){
             const metrics = ctx.measureText(text)
             const width = Math.ceil(metrics.width) - letterSpacing;
-            const height = Math.ceil(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent);
+            const height = isNaN(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent)
+              ? fontSize // browser do not support `metrics.fontBoundingBoxDescent/Ascent`
+              : Math.ceil(metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent)
 
             canvas.width = height
             canvas.height = width


### PR DESCRIPTION
## firefox的问题

make.js里`metrics.fontBoundingBoxDescent`和`metrics.fontBoundingBoxAscent`在firefox下不支持。我做了适当的替换，换成了用`fontSize`表示。不知是否合适。（我测试了一下应该没问题）

## safari阴影
其实我没有遇到 issue#1 那种三叠重影，只是发现阴影有点重。我在 make.js 中的 `ctx.shadowBlur` 做了适当的修改。
当然系数我不知道多少合适，有待讨论，我标在 221 行注释里了。

## 预览

### 桌面（chrome  safari  firefox）
![desktop](https://user-images.githubusercontent.com/64010148/178408568-cb4f7610-13c6-4c72-9981-da7dd372d5ea.png)

### firefox ios
![IMG_0846](https://user-images.githubusercontent.com/64010148/178408617-f2f295a8-2d01-40cb-a34e-f3ecb1a908f1.PNG)

### chorme ios
![IMG_0847](https://user-images.githubusercontent.com/64010148/178408622-27939e71-5250-48d1-b212-2e51b8170c96.PNG)

### safari ios
![IMG_0848](https://user-images.githubusercontent.com/64010148/178408645-f26adde5-0420-4108-bee7-5289bd28b98b.PNG)

