### PR TITLE
添加新剧场版标题生成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ html/Gruntfile.js
 html/package.json
 html/logo*
 vue.2.6.11.min.js
+node_modules
+pnpm-lock.yaml

--- a/html/document.js
+++ b/html/document.js
@@ -165,6 +165,10 @@ const outputRatios = [
         text: '16:9'
     },
     {
+        value: 2.333,
+        text: '21:9'
+    },
+    {
         value: 1,
         text: '3:3'
     },
@@ -207,6 +211,22 @@ const plans = [
     {
         value:'by',
         text:'黑黄'
+    },
+    {
+        value:'1.11',
+        text:'序'
+    },
+    {
+        value:'2.22',
+        text:'破'
+    },
+    {
+        value:'3.33',
+        text:'Q'
+    },
+    {
+        value:'3.0+1.11',
+        text:'终'
     },
     // {
     //     value:'yb',
@@ -378,52 +398,54 @@ let outputCanvas = createCanvas();
 let canvas = createCanvas();
 
 const c = async callback=>{
-    loadFont('notdef','NotDefault.woff2',async _=>{
-        loadFont('baseSplit','base-split.woff?r=220716',async _=>{
-            getFontFromText(fontFamilyName,getMoji(),async _=>{
-                layouts.slice().sort(_=>-1).forEach((layout,index)=>{
-                    let texts = [
-                        // '使徒',
-                        // '襲来',
-                        // '第壱話',
-                    ];
-                    texts = layout.inputs.map((input,index)=>{
-                        return texts[index] || input.placeholder
-                    })
-                    const height = 240;
-                    const config = Object.assign({},defaultConfig,layout.config,{
-                        height,
-                        // convolute: true,
-                        noise:false,
-                        blur:1,
-                        // inverse: Math.random()>0.9,
-                    });
-                    make({
-                        outputCanvas,
-                        canvas,
-                        texts,
-                        config,
-                        layout
-                    })
-                    const src = makeBMPFormCanvas(outputCanvas)
-                    layout.src = src;
-                    // console.log(src)
-                    // app.$set(layout,'src',src)
-                    // outputEl.appendChild(el)
+    loadFont('eva-eb', 'MatissePro.woff2',async _=> {
+        loadFont('notdef','NotDefault.woff2',async _=>{
+            loadFont('baseSplit','base-split.woff?r=220716',async _=>{
+                getFontFromText(fontFamilyName,getMoji(),async _=>{
+                    layouts.slice().sort(_=>-1).forEach((layout,index)=>{
+                        let texts = [
+                            // '使徒',
+                            // '襲来',
+                            // '第壱話',
+                        ];
+                        texts = layout.inputs.map((input,index)=>{
+                            return texts[index] || input.placeholder
+                        })
+                        const height = 240;
+                        const config = Object.assign({},defaultConfig,layout.config,{
+                            height,
+                            // convolute: true,
+                            noise:false,
+                            blur:1,
+                            // inverse: Math.random()>0.9,
+                        });
+                        make({
+                            outputCanvas,
+                            canvas,
+                            texts,
+                            config,
+                            layout
+                        })
+                        const src = makeBMPFormCanvas(outputCanvas)
+                        layout.src = src;
+                        // console.log(src)
+                        // app.$set(layout,'src',src)
+                        // outputEl.appendChild(el)
 
-                    // if(layout.exemples){
-                    //     layout.exemples.forEach(texts=>{
-                    //         const el = make({
-                    //             texts,
-                    //             config,
-                    //             layout
-                    //         })
-                    //         // outputEl.appendChild(el)
-                    //     })
-                    // }
+                        // if(layout.exemples){
+                        //     layout.exemples.forEach(texts=>{
+                        //         const el = make({
+                        //             texts,
+                        //             config,
+                        //             layout
+                        //         })
+                        //         // outputEl.appendChild(el)
+                        //     })
+                        // }
+                    })
+                    app.layouts = layouts;
+                    callback()
                 })
-                app.layouts = layouts;
-                callback()
             })
         })
     })

--- a/html/index.html
+++ b/html/index.html
@@ -142,7 +142,7 @@
 	</div>
 </div>
 
-<script src="/vue.2.6.11.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js"></script>
 <!--merge:js-->
 <script src="eva-matisse-classic-moji-list.js"></script>
 <script src="transform-func.js"></script>

--- a/html/layouts.js
+++ b/html/layouts.js
@@ -1579,6 +1579,271 @@ const layouts = [
 
         }
     },
-    
+    {
+        id: 'eva_1.11',
+        title: 'ヱヴァンゲリヲン新劇場版：序',
+        inputs:[
+            {
+                placeholder:'ヱヴァンゲリヲン新劇場版：序',
+                minLength:2,
+                maxLength:24,
+            },
+        ],
+        config:{
+            height:1080,
+            blur:false,
+            noise:false,
+            plan:'1.11',
+            outputRatio:1.778,
+        },
+        make:({
+            canvas,
+            ctx,
+            texts,
+            config,
+            functions,
+        })=>{
+            const {
+                width,
+                height,
+                scale,
+                padding,
+                space,
+                fontColor,
+            } = config;
+            
+            const {
+                randOne,
+                setCtxConfig,
+                makeTextCanvas,
+                makeTextSizeDiffCanvas,
+                makeLinesCanvas,
+                makeLinesDiffSizeCanvas,
+                makeVerticalTextCanvas,
+            } = functions;
+
+            const [text,sub] = texts;
+
+                // 序
+                const textCanvas = makeTextCanvas(text,-space);
+                const _config = randOne([
+                    {
+                        heightScale: 0.30,
+                        padding: padding,
+                        borderWidth: space * 0.2,
+                    },
+                ]);
+                const textHeight = height * _config.heightScale;
+                const textWidth = Math.min(textHeight * textCanvas.width / textCanvas.height, width * 0.65);
+
+                ctx.drawImage(
+                    textCanvas,
+                    (width - textWidth) / 2, ( height - textHeight ) / 2,
+                    textWidth,textHeight
+                );
+                // ctx.strokeStyle = fontColor;
+                // ctx.lineWidth = _config.borderWidth;
+        }
+    },
+    {
+        id: 'eva_2.22',
+        title: 'ヱヴァンゲリヲン新劇場版：破',
+        inputs:[
+            {
+                placeholder:'ヱヴァンゲリヲン新劇場版：破',
+                minLength:2,
+                maxLength:24,
+            },
+        ],
+        config:{
+            height:1080,
+            blur:false,
+            noise:false,
+            outputRatio:1.778,
+            plan:'2.22'
+        },
+        make:({
+            canvas,
+            ctx,
+            texts,
+            config,
+            functions,
+        })=>{
+            const {
+                width,
+                height,
+                scale,
+                padding,
+                space,
+                fontColor,
+            } = config;
+            
+            const {
+                randOne,
+                setCtxConfig,
+                makeTextCanvas,
+                makeTextSizeDiffCanvas,
+                makeLinesCanvas,
+                makeLinesDiffSizeCanvas,
+                makeVerticalTextCanvas,
+            } = functions;
+
+            const [text,sub] = texts;
+
+                // 序
+                const textCanvas = makeTextCanvas(text,-space);
+                const _config = randOne([
+                    {
+                        heightScale: 0.45,
+                        padding: padding,
+                        borderWidth: space * 0.2,
+                    },
+                ]);
+                const textHeight = height * _config.heightScale;
+                const textWidth = width * 0.85;
+
+                ctx.drawImage(
+                    textCanvas,
+                    (width - textWidth) / 2, ( height - textHeight ) / 2,
+                    textWidth,textHeight
+                );
+                // ctx.strokeStyle = fontColor;
+                // ctx.lineWidth = _config.borderWidth;
+        }
+    },
+    {
+        id: 'eva_3.33',
+        title: 'ヱヴァンゲリヲン新劇場版：Q',
+        inputs:[
+            {
+                placeholder:'ヱヴァンゲリヲン新劇場版：Q',
+                minLength:2,
+                maxLength:24,
+            },
+        ],
+        config:{
+            height:814,
+            blur:false,
+            noise:false,
+            outputRatio:2.333,
+            plan:'3.33'
+        },
+        make:({
+            canvas,
+            ctx,
+            texts,
+            config,
+            functions,
+        })=>{
+            const {
+                width,
+                height,
+                scale,
+                padding,
+                space,
+                fontColor,
+            } = config;
+            
+            const {
+                randOne,
+                setCtxConfig,
+                makeTextCanvas,
+                makeTextSizeDiffCanvas,
+                makeLinesCanvas,
+                makeLinesDiffSizeCanvas,
+                makeVerticalTextCanvas,
+            } = functions;
+
+            const [text,sub] = texts;
+
+                // 序
+                const textCanvas = makeTextCanvas(text,-space);
+                const _config = randOne([
+                    {
+                        heightScale: 0.6,
+                        padding: padding,
+                        borderWidth: space * 0.2,
+                    },
+                ]);
+                const textHeight = height * _config.heightScale;
+                const textWidth = width * 0.85;
+
+                ctx.drawImage(
+                    textCanvas,
+                    (width - textWidth) / 2, ( height - textHeight ) / 2,
+                    textWidth,textHeight
+                );
+                // ctx.strokeStyle = fontColor;
+                // ctx.lineWidth = _config.borderWidth;
+        }
+    },
+    {
+        id: 'eva_3.0+1.11',
+        title: 'シン･エヴァンゲリオン劇場版𝄇',
+        inputs:[
+            {
+                placeholder:'シン･エヴァンゲリオン劇場版𝄇',
+                minLength:2,
+                maxLength:24,
+            },
+        ],
+        config:{
+            // height:816,
+            height:814,
+            blur:false,
+            noise:false,
+            // outputRatio:2.353,
+            outputRatio:2.333,
+            plan:'3.0+1.11'
+        },
+        make:({
+            canvas,
+            ctx,
+            texts,
+            config,
+            functions,
+        })=>{
+            const {
+                width,
+                height,
+                scale,
+                padding,
+                space,
+                fontColor,
+            } = config;
+            
+            const {
+                randOne,
+                setCtxConfig,
+                makeTextCanvas,
+                makeTextSizeDiffCanvas,
+                makeLinesCanvas,
+                makeLinesDiffSizeCanvas,
+                makeVerticalTextCanvas,
+            } = functions;
+
+            const [text,sub] = texts;
+
+                // 序
+                const textCanvas = makeTextCanvas(text,-space);
+                const _config = randOne([
+                    {
+                        heightScale: 0.3,
+                        padding: padding,
+                        borderWidth: space * 0.2,
+                    },
+                ]);
+                const textHeight = height * _config.heightScale;
+                const textWidth = width * 0.9;
+
+                ctx.drawImage(
+                    textCanvas,
+                    (width - textWidth) / 2, ( height - textHeight ) / 2,
+                    textWidth,textHeight
+                );
+                // ctx.strokeStyle = fontColor;
+                // ctx.lineWidth = _config.borderWidth;
+        }
+    },
 
 ]

--- a/html/make.js
+++ b/html/make.js
@@ -17,7 +17,8 @@ let fontWeight = 900;
 let fontFamilyName = 'EVAMatisseClassic'
 const engFontFamilyName = `"Times New Roman"`
 
-let baseFontFamilyName = 'EVA_Matisse_Classic-EB,MatissePro-EB,baseSplit,notdef,SourceHanSerifCN-Heavy,serif';
+let baseFontFamilyName = 'EVA_Matisse_Classic-EB,MatissePro-EB,eva-eb,baseSplit,notdef,SourceHanSerifCN-Heavy,serif';
+// let baseFontFamilyName = 'eva-eb,baseSplit,notdef';
 
 
 const defaultOutputRatio = 1.334;
@@ -154,7 +155,8 @@ const make = ({
 
 
     const insetHeight = config.height || 480;
-    const insetWidth = Math.floor(insetHeight * defaultOutputRatio);
+    const insetWidth = Math.floor(insetHeight * config.outputRatio);
+    // const insetWidth = Math.floor(insetHeight * defaultOutputRatio);
 
     let renderScale = 2;
 
@@ -221,6 +223,26 @@ const make = ({
             fontColor = '#140202'
             backgroundColor = '#e77205'
             shadowColor = 'rgba(231,120,0,.5)'
+            break;
+        case '1.11':
+            fontColor = '#7B1020'
+            backgroundColor = '#000000'
+            shadowColor = 'rgba(0,0,0,0)'
+            break;
+        case '2.22':
+            fontColor = '#EF4507'
+            backgroundColor = '#000000'
+            shadowColor = 'rgba(0,0,0,0)'
+            break;
+        case '3.33':
+            fontColor = '#0DAFB4'
+            backgroundColor = '#000000'
+            shadowColor = 'rgba(0,0,0,0)'
+            break;
+        case '3.0+1.11':
+            fontColor = '#F1FEED'
+            backgroundColor = '#000000'
+            shadowColor = 'rgba(0,0,0,0)'
             break;
     }
     ctx.fillStyle = backgroundColor;

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "eva-title",
   "version": "1.0.0",
   "description": "EVA标题生成器",
-  "main": "index.html",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "itorr",
@@ -11,5 +13,8 @@
   "dependencies": {
     "express": "^4.18.1",
     "fontmin": "^0.9.9"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.0"
   }
 }


### PR DESCRIPTION
因为个人所需所以修改了下，添加了新剧场版四部曲的标题生成

对照[这个网站的剧照截图](https://fancaps.net/search.php?q=Evangelion&MoviesCB=Movies&TVCB=TV&animeCB=Anime&submit=%E6%8F%90%E4%BA%A4)一点点调的，起码看起来比较像了。

已知问题是日文做不到剧照那么密集，以及终止符𝄇显示不像剧照那么宽